### PR TITLE
[Refactor] separate image message & OpenCV image classification, use dictionary for classes

### DIFF
--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -102,7 +102,7 @@ data
 ├── class_1
 └── class_2
 ```
-should returns
+should return
 ```
 {0: 'class_1', 1: 'class_2'}
 ```

--- a/docs/python_package.md
+++ b/docs/python_package.md
@@ -95,7 +95,8 @@ An extension of `SceneDetectionActionServer` which uses `SingleImageDetectionHan
 from an image extracted from a `sensor_msgs/PointCloud2` message, while also fitting planes in the clouds.
 
 ## [`utils.py`](../ros/src/mas_perception_libs/utils.py)
-* `get_classes_in_data_dir`: Returns a list of strings as class names for a directory. This directory structure
+* `get_classes_in_data_dir`: Returns a dictionary mapping from indices to classes as names of top level directories.
+This directory structure
 ```
 data
 ├── class_1
@@ -103,7 +104,7 @@ data
 ```
 should returns
 ```
-['class_1', 'class_2']
+{0: 'class_1', 1: 'class_2'}
 ```
 when called on `data`.
 * `process_image_message`: Converts `sensor_msgs/Image` to CV image, then resizes and/or runs a preprocessing function

--- a/ros/src/mas_perception_libs/image_recognition_service.py
+++ b/ros/src/mas_perception_libs/image_recognition_service.py
@@ -38,7 +38,7 @@ class RecognizeImageService(object):
         rospy.loginfo('number of images to recognize: ' + str(len(req.images)))
         if req.model_name not in self._classifiers:
             model_path = os.path.join(self._model_dir, req.model_name + '.h5')
-            class_file = os.path.join(self._model_dir, req.model_name + '.txt')
+            class_file = os.path.join(self._model_dir, req.model_name + '.yml')
             rospy.loginfo('recognition model path: ' + model_path)
             rospy.loginfo('recognition class file path: ' + class_file)
             self._classifiers[req.model_name] = self._classifier_class(model_path=model_path, class_file=class_file)

--- a/ros/src/mas_perception_libs/utils.py
+++ b/ros/src/mas_perception_libs/utils.py
@@ -89,14 +89,16 @@ def get_bag_file_msg_by_type(bag_file_path, msg_type):
 def get_classes_in_data_dir(data_dir):
     """
     :type data_dir: str
-    :return: list of classes as names of top level directories
+    :return: dictionary mapping from indices to classes as names of top level directories
     """
-    classes = []
+    class_dict = {}
+    index = 0
     for subdir in sorted(os.listdir(data_dir)):
         if os.path.isdir(os.path.join(data_dir, subdir)):
-            classes.append(subdir)
+            class_dict[index] = subdir
+            index += 1
 
-    return classes
+    return class_dict
 
 
 def process_image_message(image_msg, cv_bridge, target_size=None, func_preprocess_img=None):


### PR DESCRIPTION
## Changelog
* break the `classify` function into `classify` and `classify_np_images`, where the latter may classify a list of OpenCV images and the former a list of `sensor_msgs/Image` messages
* use dictionary to keep track of classes in `ImageClassifier`, update relevant function and documentation

## Motivation
* allow for classifying OpenCV images directly, which is needed by b-it-bots/mas_domestic_robotics#152 for cutout face and body images
* make keeping track of classes for `ImageClassifier` consistent with `ImageDetector` and more flexible (e.g. allow for skipping classes)

## QA
* tested locally with the object recognition service and corresponding test script

```roslaunch mdr_object_recognition object_recognition.launch```
```rosrun mas_perception_libs -t ${IMAGE_DIR} -s ${SERVICE_NAME} ${MODEL_NAME}```
