### PR TITLE
[WIP] Obstacle detection using point clouds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ catkin_python_setup()
 
 generate_dynamic_reconfigure_options(
   ros/config/PlaneFitting.cfg
+  ros/config/ObstacleDetection.cfg
 )
 
 ###################################
@@ -104,6 +105,17 @@ target_link_libraries(cloud_processing_cpp_test
   ${OpenCV_LIBRARIES}
 )
 
+###################################
+# Node for obstacle detection
+add_executable(cloud_obstacle_detection
+  ros/src/cloud_obstacle_detection.cpp
+)
+target_link_libraries(cloud_obstacle_detection
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+)
+
 #############
 ## Testing ##
 #############
@@ -153,5 +165,9 @@ install(PROGRAMS
 )
 
 install(TARGETS cloud_processing_cpp_test
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS cloud_obstacle_detection
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/ros/config/ObstacleDetection.cfg
+++ b/ros/config/ObstacleDetection.cfg
@@ -52,4 +52,21 @@ euclidean_clustering_params.add("max_cluster_size", int_t, 0,
                         "The maximum number of points that a cluster needs to contain in order to be considered valid",
                         1000, 0, 10000)
 
+# Obstacle Cache
+obstacle_cache_params = gen.add_group("Obstacle Cache")
+obstacle_cache_params.add("obstacle_cache_time", double_t, 0, 
+                        "Maximum time (in seconds) for which an obstacle can say in cache after it is no longer visible/detected.",
+                        5, 0, 100)
+obstacle_cache_params.add("similarity_threshold", double_t, 0, 
+                        "threshold for identifying outliers and not considering those for the similarity \
+                         a good value for threshold is 5 * <cloud_resolution>, e.g. 10cm for a cloud with 2cm resolution",
+                        2.0, 0.0, 100.0)
+obstacle_cache_params.add("position_history_cache_size", int_t, 0, 
+                        "Maximum number of past obstacle positions to remember",
+                        10, 0, 1000)
+obstacle_cache_params.add("uniqueness_threshold", double_t, 0, 
+                        "Threshold to determine a new cluster is the same as a cached cluster. \
+                         If the similarity measure is below this value, the new cluster is considered as a replica of a cached cluster.",
+                        0.005, 0.0, 10.0)
+
 exit (gen.generate (PACKAGE, NODE_NAME, "ObstacleDetection"))

--- a/ros/config/ObstacleDetection.cfg
+++ b/ros/config/ObstacleDetection.cfg
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2
+from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, int_t, bool_t, str_t
+
+
+PACKAGE='mas_perception_libs'
+NODE_NAME = PACKAGE
+
+gen = ParameterGenerator()
+
+# cloud filter group
+cloud_filter_params = gen.add_group("Cloud Filter")
+
+# pass-through filter parameters
+cloud_filter_params.add("passthrough_limit_min_x", double_t, 0,
+                        "Minimum field value of a point along x-axis for it to be considered", 0.0, 0.0, 10.0)
+
+cloud_filter_params.add("passthrough_limit_max_x", double_t, 0,
+                        "Maximum field value of a point along x-axis for it to be considered", 3.0, 0.0, 10.0)
+
+cloud_filter_params.add("passthrough_limit_min_y", double_t, 0,
+                        "Minimum field value of a point along y-axis for it to be considered", -1.5, -3.0, 3.0)
+
+cloud_filter_params.add("passthrough_limit_max_y", double_t, 0,
+                        "Maximum field value of a point along y-axis for it to be considered", 1.5, -3.0, 3.0)
+
+cloud_filter_params.add("passthrough_limit_min_z", double_t, 0,
+                        "Minimum field value of a point along z-axis for it to be considered", 0.025, 0.0, 5.0)
+
+cloud_filter_params.add("passthrough_limit_max_z", double_t, 0,
+                        "Maximum field value of a point along z-axis for it to be considered", 0.2, 0.0, 5.0)
+
+# voxel-grid filter parameters; note that we limit the cloud along the z-axis using the voxel filter to avoid adding
+# a third pass-through filter
+cloud_filter_params.add("voxel_limit_min_z", double_t, 0,
+                        "Minimum field value of a point along z-axis for it to be considered", 0.0, -10.0, 10.0)
+cloud_filter_params.add("voxel_limit_max_z", double_t, 0,
+                        "Maximum field value of a point along z-axis for it to be considered", 1.0, -10.0, 10.0)
+cloud_filter_params.add("voxel_leaf_size", double_t, 0, "Size of a leaf (on x,y,z) used for downsampling.",
+                        0.01, 0, 1.0)
+
+# Euclidean Clustering
+euclidean_clustering_params = gen.add_group("Euclidean Clustering")
+
+# clustering parameters
+euclidean_clustering_params.add("cluster_tolerance", double_t, 0, 
+                        "Spatial cluster tolerance as a measure in the L2 Euclidean space",
+                        0.03, 0.0, 0.1)
+euclidean_clustering_params.add("min_cluster_size", int_t, 0, 
+                        "The minimum number of points that a cluster needs to contain in order to be considered valid",
+                        5, 0, 1000)
+euclidean_clustering_params.add("max_cluster_size", int_t, 0, 
+                        "The maximum number of points that a cluster needs to contain in order to be considered valid",
+                        1000, 0, 10000)
+
+exit (gen.generate (PACKAGE, NODE_NAME, "ObstacleDetection"))

--- a/ros/config/obstacle_detection_default_configs.yaml
+++ b/ros/config/obstacle_detection_default_configs.yaml
@@ -1,7 +1,7 @@
 # config file loaded during launch as default configurations for the cloud filter, assuming base_link frame for
 # passthrough filter
 passthrough_limit_min_x:  0.0
-passthrough_limit_max_x:  3.0
+passthrough_limit_max_x:  1.5
 passthrough_limit_min_y: -1.5
 passthrough_limit_max_y:  1.5
 passthrough_limit_min_z:  0.025

--- a/ros/config/obstacle_detection_default_configs.yaml
+++ b/ros/config/obstacle_detection_default_configs.yaml
@@ -1,0 +1,15 @@
+# config file loaded during launch as default configurations for the cloud filter, assuming base_link frame for
+# passthrough filter
+passthrough_limit_min_x:  0.0
+passthrough_limit_max_x:  3.0
+passthrough_limit_min_y: -1.5
+passthrough_limit_max_y:  1.5
+passthrough_limit_min_z:  0.025
+passthrough_limit_max_z:  0.2
+voxel_limit_min_z:        0.0
+voxel_limit_max_z:        1.8
+voxel_leaf_size:          0.02
+# config file loaded during launch as default configurations for the clustering algorithm
+cluster_tolerance:       0.03
+min_cluster_size:        5
+max_cluster_size:        1000

--- a/ros/config/obstacle_detection_default_configs.yaml
+++ b/ros/config/obstacle_detection_default_configs.yaml
@@ -2,7 +2,7 @@
 # passthrough filter
 passthrough_limit_min_x:  0.0
 passthrough_limit_max_x:  1.5
-passthrough_limit_min_y: -1.5
+passthrough_limit_min_y: -0.5
 passthrough_limit_max_y:  1.5
 passthrough_limit_min_z:  0.025
 passthrough_limit_max_z:  0.2
@@ -13,3 +13,8 @@ voxel_leaf_size:          0.02
 cluster_tolerance:       0.03
 min_cluster_size:        5
 max_cluster_size:        1000
+# Obstacle Cache
+obstacle_cache_time:            5
+similarity_threshold:           2.0
+position_history_cache_size:    10
+uniqueness_threshold:           0.005

--- a/ros/launch/cloud_obstacle_detection_cpp_test.launch
+++ b/ros/launch/cloud_obstacle_detection_cpp_test.launch
@@ -3,7 +3,8 @@
     <arg name="cloud_topic" default=""/>
     <arg name="processed_cloud_topic" default="processed_cloud"/>
     <arg name="obstacle_cloud_topic" default="obstacle_cloud"/>
-    <arg name="target_frame" default="/base_link" />
+    <arg name="transform_target_frame" default="/base_link" />
+    <arg name="cluster_target_frame" default="/base_link" />
     <arg name="obstacles_detection_topic" default="/detected_obstacles"/>
     <arg name="obstacle_detection_config_file"
          default="$(find mas_perception_libs)/ros/config/obstacle_detection_default_configs.yaml" />
@@ -15,7 +16,8 @@
         <param name="processed_cloud_topic" type="string" value="$(arg processed_cloud_topic)" />
         <param name="obstacle_cloud_topic" type="string" value="$(arg obstacle_cloud_topic)" />
         <param name="obstacles_detection_topic" type="string" value="$(arg obstacles_detection_topic)" />
-        <param name="target_frame" type="string" value="$(arg target_frame)" />
+        <param name="transform_target_frame" type="string" value="$(arg transform_target_frame)" />
+        <param name="cluster_target_frame" type="string" value="$(arg cluster_target_frame)" />
     </node>
 
     <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan_node" output="screen"

--- a/ros/launch/cloud_obstacle_detection_cpp_test.launch
+++ b/ros/launch/cloud_obstacle_detection_cpp_test.launch
@@ -2,6 +2,7 @@
 <launch>
     <arg name="cloud_topic" default=""/>
     <arg name="processed_cloud_topic" default="processed_cloud"/>
+    <arg name="obstacle_cloud_topic" default="obstacle_cloud"/>
     <arg name="target_frame" default="/base_link" />
     <arg name="obstacles_detection_topic" default="/detected_obstacles"/>
     <arg name="obstacle_detection_config_file"
@@ -12,7 +13,14 @@
         <rosparam file="$(arg obstacle_detection_config_file)" command="load"/>
         <param name="cloud_topic" type="string" value="$(arg cloud_topic)" />
         <param name="processed_cloud_topic" type="string" value="$(arg processed_cloud_topic)" />
+        <param name="obstacle_cloud_topic" type="string" value="$(arg obstacle_cloud_topic)" />
         <param name="obstacles_detection_topic" type="string" value="$(arg obstacles_detection_topic)" />
         <param name="target_frame" type="string" value="$(arg target_frame)" />
+    </node>
+
+    <node pkg="pointcloud_to_laserscan" type="pointcloud_to_laserscan_node" name="pointcloud_to_laserscan_node" output="screen"
+          ns="mas_perception">
+        <remap from="cloud_in" to="cloud_obstacle_detection/$(arg obstacle_cloud_topic)" />
+        <remap from="scan" to="obstacle_scan" />
     </node>
 </launch>

--- a/ros/launch/cloud_obstacle_detection_cpp_test.launch
+++ b/ros/launch/cloud_obstacle_detection_cpp_test.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="cloud_topic" default=""/>
+    <arg name="processed_cloud_topic" default="processed_cloud"/>
+    <arg name="target_frame" default="/base_link" />
+    <arg name="obstacles_detection_topic" default="/detected_obstacles"/>
+    <arg name="obstacle_detection_config_file"
+         default="$(find mas_perception_libs)/ros/config/obstacle_detection_default_configs.yaml" />
+
+    <node pkg="mas_perception_libs" type="cloud_obstacle_detection" name="cloud_obstacle_detection" output="screen"
+          ns="mas_perception">
+        <rosparam file="$(arg obstacle_detection_config_file)" command="load"/>
+        <param name="cloud_topic" type="string" value="$(arg cloud_topic)" />
+        <param name="processed_cloud_topic" type="string" value="$(arg processed_cloud_topic)" />
+        <param name="obstacles_detection_topic" type="string" value="$(arg obstacles_detection_topic)" />
+        <param name="target_frame" type="string" value="$(arg target_frame)" />
+    </node>
+</launch>

--- a/ros/src/cloud_obstacle_detection.cpp
+++ b/ros/src/cloud_obstacle_detection.cpp
@@ -119,17 +119,30 @@ private:
     ros::Publisher mObstacleCloudPub;
     ros::Publisher mMarkerPub;
     tf::TransformListener mTfListener;
-    std::string mTargetFrame;
+    std::string mTransformTargetFrame;
+    std::string mClusterTargetFrame;
     CloudPassThroughVoxelFilter mCloudFilter;
     EuclideanClusterParams mClusterParams;
+
+    double mSimilarityThreshold;
+    double mUniquenessThreshold;
+    unsigned int mPositionCacheLimit;
+    unsigned int mUniqueObstacleId;
+    float mObstacleCacheTime;
+    unsigned int mCurrTime;
+    std::map<int, int> mLastSeenTimeCache;
+    std::map<int, const PointCloud::Ptr> mObstaclesCache;
+    std::map<int, std::vector<Eigen::Vector4f>> mPrevPositionsCache;
 
 public:
     CloudObstacleDetectionNode(const ros::NodeHandle &pNodeHandle, const std::string &pCloudTopic,
             const std::string &pProcessedCloudTopic, 
-            const std::string &pObstacleCloudTopic, 
-            const std::string &pTargetFrame, 
+            const std::string &pObstacleCloudTopic,
+            const std::string &pTransformTargetFrame,
+            const std::string &pClusterTargetFrame,
             const std::string &pObstaclesDetectionTopic)
-    : mNodeHandle(pNodeHandle), mObstacleDetectionConfigServer(mNodeHandle), mTargetFrame(pTargetFrame)
+    : mNodeHandle(pNodeHandle), mObstacleDetectionConfigServer(mNodeHandle), 
+      mTransformTargetFrame(pTransformTargetFrame), mClusterTargetFrame(pClusterTargetFrame)
     {
         ROS_INFO("setting up dynamic reconfiguration server for obstacle detection");
         auto odCallback = boost::bind(&CloudObstacleDetectionNode::obstacleDetectionConfigCallback, this, _1, _2);
@@ -159,10 +172,16 @@ private:
         cloudFilterParams.mVoxelLeafSize = static_cast<float>(pConfig.voxel_leaf_size);
         mCloudFilter.setParams(cloudFilterParams);
 
-        // CLoud CLustering params
+        // Cloud Clustering params
         mClusterParams.mClusterTolerance = static_cast<float>(pConfig.cluster_tolerance);
         mClusterParams.mMinClusterSize = static_cast<unsigned int>(pConfig.min_cluster_size);
         mClusterParams.mMaxClusterSize = static_cast<unsigned int>(pConfig.max_cluster_size);
+
+        // Obstacle cache params
+        mObstacleCacheTime = static_cast<unsigned int>(pConfig.obstacle_cache_time);
+        mSimilarityThreshold = static_cast<float>(pConfig.similarity_threshold);
+        mUniquenessThreshold = static_cast<float>(pConfig.uniqueness_threshold);
+        mPositionCacheLimit = static_cast<float>(pConfig.position_history_cache_size);
     }
 
     void
@@ -176,10 +195,10 @@ private:
 
         // transform the cloud to a desired frame
         auto transformedCloudPtr = boost::make_shared<sensor_msgs::PointCloud2>();
-        if (!pcl_ros::transformPointCloud(mTargetFrame, *pCloudMsgPtr, *transformedCloudPtr, mTfListener))
+        if (!pcl_ros::transformPointCloud(mTransformTargetFrame, *pCloudMsgPtr, *transformedCloudPtr, mTfListener))
         {
             ROS_WARN("failed to transform cloud to frame '%s' from frame '%s'",
-                     mTargetFrame.c_str(), pCloudMsgPtr->header.frame_id.c_str());
+                     mTransformTargetFrame.c_str(), pCloudMsgPtr->header.frame_id.c_str());
             return;
         }
 
@@ -187,6 +206,15 @@ private:
         PointCloud::Ptr pclCloudPtr = boost::make_shared<PointCloud>();
         pcl::fromROSMsg(*transformedCloudPtr, *pclCloudPtr);
         PointCloud::Ptr filteredCloudPtr = mCloudFilter.filterCloud(pclCloudPtr);
+
+        if (filteredCloudPtr->size() < mClusterParams.mMinClusterSize)
+        {
+            // Stop processing the point cloud if the filtered cloud does 
+            // not have enough points to create even one cluster
+            return;
+        }
+
+        mCurrTime = pCloudMsgPtr->header.stamp.sec;
 
         if (mFilteredCloudPub.getNumSubscribers() > 0)
         {
@@ -198,35 +226,35 @@ private:
         pcl::search::Search<PointT>::Ptr tree(new pcl::search::KdTree<PointT>);
         tree->setInputCloud(filteredCloudPtr);
         std::vector<pcl::PointIndices> cluster_indices;
+        std::vector<PointCloud::Ptr> clusterClouds;
         pcl::extractEuclideanClusters(*filteredCloudPtr,
                                       tree,
                                       mClusterParams.mClusterTolerance,
                                       cluster_indices,
                                       mClusterParams.mMinClusterSize,
                                       mClusterParams.mMaxClusterSize);
+        getClusterClouds(clusterClouds, filteredCloudPtr, cluster_indices);
 
-        if (mMarkerPub.getNumSubscribers() > 0)
-        {
-            publishClusterMarkers(filteredCloudPtr, cluster_indices);
-        }
+        processNewClusters(clusterClouds);
+        removeStaleObstacles();
 
-        if (mObstacleCloudPub.getNumSubscribers() > 0)
-        {
-            publishObstacleCloud(filteredCloudPtr, cluster_indices);
-        }
+        publishObstacleCloud();
+        publishClusterMarkers();
     }
 
-    void 
-    publishClusterMarkers(PointCloud::ConstPtr filteredCloud, 
-                          const std::vector<pcl::PointIndices>& cluster_indices)
+    void
+    publishClusterMarkers()
     {
+        if (mMarkerPub.getNumSubscribers() <= 0)
+            return;
+
         visualization_msgs::MarkerArray markerArray;
-        int i = 0;
-        for (const auto& indices: cluster_indices)
+        for (const auto& c : mObstaclesCache)
         {
             Eigen::Vector4f min, max;
-            pcl::getMinMax3D(*filteredCloud, indices, min, max);
-            markerArray.markers.push_back(getMarker(min, max, i++));
+            pcl::getMinMax3D(*(c.second), min, max);
+            markerArray.markers.push_back(getMarker(min, max, c.first));
+            markerArray.markers.push_back(getTextLabel(min, max, c.first));
         }
         // Publish the marker array
         mMarkerPub.publish(markerArray);
@@ -248,8 +276,8 @@ private:
         visualization_msgs::Marker marker;
         marker.type = visualization_msgs::Marker::LINE_LIST;
         marker.action = visualization_msgs::Marker::ADD;
-        marker.lifetime = ros::Duration(2.0);
-        marker.header.frame_id = mTargetFrame;
+        marker.lifetime = ros::Duration(1.0);
+        marker.header.frame_id = mTransformTargetFrame;
         marker.scale.x = 0.005;
         marker.scale.y = 0.005;
         marker.color.a = 2.0;
@@ -267,18 +295,173 @@ private:
         return marker;
     }
 
-    void
-    publishObstacleCloud(PointCloud::ConstPtr filteredCloud, 
-                         const std::vector<pcl::PointIndices>& cluster_indices)
+    visualization_msgs::Marker 
+    getTextLabel(const Eigen::Vector4f& min, const Eigen::Vector4f& max, int id)
     {
-        PointCloud::Ptr mergedCloud(new PointCloud);
+        Eigen::Vector4f center = min + (max - min)/2.0;
+        visualization_msgs::Marker marker;
+        marker.type = visualization_msgs::Marker::TEXT_VIEW_FACING;
+        marker.text = std::to_string(id);
+        marker.lifetime = ros::Duration(1.0);
+        marker.header.frame_id = mTransformTargetFrame;
+        marker.pose.position.x = center[0];
+        marker.pose.position.y = center[1];
+        marker.pose.position.z = center[2];
+        marker.scale.z = 0.05;
+        marker.id = id + 1000;
+        marker.color = std_msgs::ColorRGBA(Color(Color::SCARLET));
+        return marker;
+    }
+
+    void getClusterClouds(std::vector<PointCloud::Ptr>& clusterClouds,
+                          PointCloud::ConstPtr filteredCloud, 
+                          const std::vector<pcl::PointIndices>& cluster_indices)
+    {
         for (const auto& idx: cluster_indices)
         {
+            PointCloud::Ptr clusterCloud(new PointCloud);
             for (const auto &index : idx.indices)
-                mergedCloud->push_back ((*filteredCloud)[index]); 
+                clusterCloud->push_back ((*filteredCloud)[index]);
+
+            clusterCloud->header = filteredCloud->header;
+            clusterCloud->width = clusterCloud->size();
+            clusterCloud->height = 1;
+            clusterCloud->is_dense = true;
+
+            PointCloud::Ptr transformedCloudPtr = boost::make_shared<PointCloud>();
+            pcl_ros::transformPointCloud(mClusterTargetFrame, *clusterCloud, *transformedCloudPtr, mTfListener);
+
+            clusterClouds.push_back(transformedCloudPtr);
         }
-        mergedCloud->header = filteredCloud->header;
-        mergedCloud->width = mergedCloud->size ();
+    }
+
+    // Cloud comparison sample from https://stackoverflow.com/a/55930847
+    float nearestDistance(const pcl::search::KdTree<PointT>& tree, const PointT& pt)
+    {
+        const int k = 1;
+        std::vector<int> indices (k);
+        std::vector<float> sqr_distances (k);
+
+        tree.nearestKSearch(pt, k, indices, sqr_distances);
+
+        return sqr_distances[0];
+    }
+    // compare cloudB to cloudA
+    // use threshold for identifying outliers and not considering those for the similarity
+    // a good value for threshold is 5 * <cloud_resolution>, e.g. 10cm for a cloud with 2cm resolution
+    float getCloudSimilarity(const PointCloud& cloudA, const PointCloud& cloudB, float threshold)
+    {
+        // compare B to A
+        int num_outlier = 0;
+        pcl::search::KdTree<PointT> tree;
+        tree.setInputCloud(cloudA.makeShared());
+        auto sum = std::accumulate(cloudB.begin(), cloudB.end(), 0.0f, [&](float current_sum, const PointT& pt) {
+            const auto dist = nearestDistance(tree, pt);
+
+            if(dist < threshold)
+            {
+                return current_sum + dist;
+            }
+            else
+            {
+                num_outlier++;
+                return current_sum;
+            }
+        });
+
+        return sum / (cloudB.size() - num_outlier);
+    }
+
+    bool 
+    isNewObstacle(const PointCloud& cloud, int& knownObstacleId)
+    {
+        for (const auto& o : mObstaclesCache)
+        {
+            if (getCloudSimilarity(cloud, *(o.second), mSimilarityThreshold) < mUniquenessThreshold)
+            {
+                knownObstacleId = o.first;
+                return false;
+            }
+        }
+        knownObstacleId = -1;
+        return true;
+    }
+
+    void
+    processNewClusters(const std::vector<PointCloud::Ptr>& clusterClouds)
+    {
+        for (const auto& cloud : clusterClouds)
+        {
+            Eigen::Vector4f centroid;
+            if (pcl::compute3DCentroid(*cloud, centroid) <= 0)
+            {
+                ROS_WARN("Could not compute centroid of point cloud. Skipping processing of potential obstacle cluster!");
+                return;
+            }
+
+            int obstacleID = -1;
+            if (isNewObstacle(*cloud, obstacleID))
+            {
+                obstacleID = mUniqueObstacleId++;
+                ROS_INFO("Adding new obstacle: %d", obstacleID);
+                mObstaclesCache.insert(std::pair<int, const PointCloud::Ptr>(obstacleID, cloud));
+                std::vector<Eigen::Vector4f> prevPositions;
+                prevPositions.push_back(centroid);
+                mPrevPositionsCache.insert(std::pair<int, std::vector<Eigen::Vector4f>>(obstacleID, prevPositions));
+                mLastSeenTimeCache.insert(std::pair<int, int>(obstacleID, mCurrTime));
+            }
+            else
+            {
+                // update last known position
+                std::vector<Eigen::Vector4f>& prevPositions = mPrevPositionsCache[obstacleID];
+                if (prevPositions.size() > mPositionCacheLimit)
+                {
+                    prevPositions.erase(prevPositions.begin());
+                }
+                prevPositions.push_back(centroid);
+
+                mLastSeenTimeCache[obstacleID] = mCurrTime;
+            }
+        }
+    }
+
+    void removeStaleObstacles()
+    {
+        for (auto it = mLastSeenTimeCache.cbegin(); it != mLastSeenTimeCache.cend(); )
+        {
+            int id = it->first;
+            if (mCurrTime - it->second > mObstacleCacheTime)
+            {
+                ROS_INFO("Removing Stale obstacle: %d", id);
+                mLastSeenTimeCache.erase(it++);
+                mPrevPositionsCache.erase(id);
+                mObstaclesCache.erase(id);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
+    void
+    publishObstacleCloud()
+    {
+        if (mObstacleCloudPub.getNumSubscribers() <= 0)
+            return;
+
+        // Merge all the clusters into once cloud
+        PointCloud::Ptr mergedCloud(new PointCloud);
+        bool headerInitialized = false;
+        for (const auto& c : mObstaclesCache)
+        {   if (!headerInitialized)
+            {
+                mergedCloud->header = c.second->header;
+                headerInitialized = true;
+            }
+            *mergedCloud += *(c.second);
+        }
+        mergedCloud->width = mergedCloud->size();
         mergedCloud->height = 1;
         mergedCloud->is_dense = true;
 
@@ -304,7 +487,8 @@ int main(int pArgc, char** pArgv)
     ros::NodeHandle nh("~");
 
     // load launch parameters
-    std::string cloudTopic, processedCloudTopic, obstacleCloudTopic, obstacleDetectionsTopic, targetFrame;
+    std::string cloudTopic, processedCloudTopic, obstacleCloudTopic, 
+                obstacleDetectionsTopic, transformTargetFrame, clusterTargetFrame;
     if (!nh.getParam("cloud_topic", cloudTopic) || cloudTopic.empty())
     {
         ROS_ERROR("No 'cloud_topic' specified as parameter");
@@ -325,15 +509,20 @@ int main(int pArgc, char** pArgv)
         ROS_ERROR("No 'obstacles_detection_topic' specified as parameter");
         return EXIT_FAILURE;
     }
-    if (!nh.getParam("target_frame", targetFrame) || targetFrame.empty())
+    if (!nh.getParam("transform_target_frame", transformTargetFrame) || transformTargetFrame.empty())
     {
-        ROS_ERROR("No 'target_frame' specified as parameter");
+        ROS_ERROR("No 'transform_target_frame' specified as parameter");
+        return EXIT_FAILURE;
+    }
+    if (!nh.getParam("cluster_target_frame", clusterTargetFrame) || clusterTargetFrame.empty())
+    {
+        ROS_ERROR("No 'cluster_target_frame' specified as parameter");
         return EXIT_FAILURE;
     }
 
     // run cloud filtering and obstacle detection
     mas_perception_libs::CloudObstacleDetectionNode obstacleDetection(nh, cloudTopic, processedCloudTopic, obstacleCloudTopic,
-                                                                         targetFrame, obstacleDetectionsTopic);
+                                                                         transformTargetFrame, clusterTargetFrame, obstacleDetectionsTopic);
 
     while (ros::ok())
         ros::spin();

--- a/ros/src/cloud_obstacle_detection.cpp
+++ b/ros/src/cloud_obstacle_detection.cpp
@@ -1,0 +1,295 @@
+/*!
+ * @copyright 2018 Bonn-Rhein-Sieg University
+ *
+ * @author Sushant Chavan
+ *
+ * @brief script to detect obstacles from a point cloud
+ */
+
+#include <pcl_ros/transforms.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/segmentation/extract_clusters.h>
+#include <pcl/common/common.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/voxel_grid.h>
+#include <dynamic_reconfigure/server.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <tf/transform_listener.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <mas_perception_libs/color.h>
+#include <mas_perception_libs/ObstacleDetectionConfig.h>
+
+namespace mas_perception_libs
+{
+
+/*!
+ * @brief struct containing parameters necessary for filtering point clouds
+ */
+struct CloudPassThroughVoxelFilterParams
+{
+    /* PassThrough filter parameters
+     * limit the cloud to be filtered points outside of these x, y, z ranges will be discarded */
+    float mPassThroughLimitMinX = 0.0f;
+    float mPassThroughLimitMaxX = 0.0f;
+    float mPassThroughLimitMinY = 0.0f;
+    float mPassThroughLimitMaxY = 0.0f;
+    float mPassThroughLimitMinZ = 0.0f;
+    float mPassThroughLimitMaxZ = 0.0f;
+    /* VoxelGrid filter parameters for down-sampling the cloud, also limit the cloud along the z axis */
+    float mVoxelLimitMinZ = 0.0f;
+    float mVoxelLimitMaxZ = 0.0f;
+    float mVoxelLeafSize = 0.0f;
+};
+
+/*!
+ * @brief struct containing parameters necessary for clustering point clouds
+ */
+struct EuclideanClusterParams
+{
+    float mClusterTolerance = 0.01f;
+    unsigned int mMinClusterSize = 1;
+    unsigned int mMaxClusterSize = std::numeric_limits<unsigned int>::max();
+};
+
+/*!
+ * @brief class containing definition for filtering point clouds
+ */
+class CloudPassThroughVoxelFilter
+{
+public:
+    CloudPassThroughVoxelFilter() = default;
+
+    /*! @brief set parameters relevant to filtering cloud */
+    virtual void
+    setParams(const CloudPassThroughVoxelFilterParams& pParams)
+    {
+        /* pass-through params */
+        mPassThroughFilterX.setFilterFieldName("x");
+        mPassThroughFilterX.setFilterLimits(pParams.mPassThroughLimitMinX, pParams.mPassThroughLimitMaxX);
+        mPassThroughFilterY.setFilterFieldName("y");
+        mPassThroughFilterY.setFilterLimits(pParams.mPassThroughLimitMinY, pParams.mPassThroughLimitMaxY);
+        mPassThroughFilterZ.setFilterFieldName("z");
+        mPassThroughFilterZ.setFilterLimits(pParams.mPassThroughLimitMinZ, pParams.mPassThroughLimitMaxZ);
+
+        /* filter z-axis using voxel filter instead of making another member */
+        mVoxelGridFilter.setFilterFieldName("z");
+        mVoxelGridFilter.setFilterLimits(pParams.mVoxelLimitMinZ, pParams.mVoxelLimitMaxZ);
+
+        /* voxel-grid params */
+        mVoxelGridFilter.setLeafSize(pParams.mVoxelLeafSize, pParams.mVoxelLeafSize, pParams.mVoxelLeafSize);
+    }
+
+    /*!
+    * @brief filter point cloud using passthrough and voxel filters
+    */
+    PointCloud::Ptr
+    filterCloud(const PointCloud::ConstPtr &pCloudPtr)
+    {
+        PointCloud::Ptr filteredCloudPtr = boost::make_shared<PointCloud>();
+
+        mPassThroughFilterX.setInputCloud(pCloudPtr);
+        mPassThroughFilterX.filter(*filteredCloudPtr);
+
+        mPassThroughFilterY.setInputCloud(filteredCloudPtr);
+        mPassThroughFilterY.filter(*filteredCloudPtr);
+
+        mPassThroughFilterZ.setInputCloud(filteredCloudPtr);
+        mPassThroughFilterZ.filter(*filteredCloudPtr);
+
+        mVoxelGridFilter.setInputCloud(filteredCloudPtr);
+        mVoxelGridFilter.filter(*filteredCloudPtr);
+
+        return filteredCloudPtr;
+    }
+
+private:
+    pcl::PassThrough<PointT> mPassThroughFilterX;
+    pcl::PassThrough<PointT> mPassThroughFilterY;
+    pcl::PassThrough<PointT> mPassThroughFilterZ;
+    pcl::VoxelGrid<PointT> mVoxelGridFilter;
+};
+
+class CloudObstacleDetectionNode
+{
+private:
+    ros::NodeHandle mNodeHandle;
+    dynamic_reconfigure::Server<ObstacleDetectionConfig> mObstacleDetectionConfigServer;
+    ros::Subscriber mCloudSub;
+    ros::Publisher mFilteredCloudPub;
+    ros::Publisher mMarkerPub;
+    tf::TransformListener mTfListener;
+    std::string mTargetFrame;
+    CloudPassThroughVoxelFilter mCloudFilter;
+    EuclideanClusterParams mClusterParams;
+
+public:
+    CloudObstacleDetectionNode(const ros::NodeHandle &pNodeHandle, const std::string &pCloudTopic,
+            const std::string &pProcessedCloudTopic, 
+            const std::string &pTargetFrame, 
+            const std::string &pObstaclesDetectionTopic)
+    : mNodeHandle(pNodeHandle), mObstacleDetectionConfigServer(mNodeHandle), mTargetFrame(pTargetFrame)
+    {
+        ROS_INFO("setting up dynamic reconfiguration server for obstacle detection");
+        auto odCallback = boost::bind(&CloudObstacleDetectionNode::obstacleDetectionConfigCallback, this, _1, _2);
+        mObstacleDetectionConfigServer.setCallback(odCallback);
+
+        ROS_INFO("subscribing to point cloud topic and advertising processed result");
+        mCloudSub = mNodeHandle.subscribe(pCloudTopic, 1, &CloudObstacleDetectionNode::cloudCallback, this);
+        mFilteredCloudPub = mNodeHandle.advertise<sensor_msgs::PointCloud2>(pProcessedCloudTopic, 1);
+        mMarkerPub = mNodeHandle.advertise<visualization_msgs::MarkerArray>(pObstaclesDetectionTopic, 1);
+    }
+
+private:
+    void
+    obstacleDetectionConfigCallback(const ObstacleDetectionConfig &pConfig, uint32_t pLevel)
+    {
+        // Cloud Filter params
+        CloudPassThroughVoxelFilterParams cloudFilterParams;
+        cloudFilterParams.mPassThroughLimitMinX = static_cast<float>(pConfig.passthrough_limit_min_x);
+        cloudFilterParams.mPassThroughLimitMaxX = static_cast<float>(pConfig.passthrough_limit_max_x);
+        cloudFilterParams.mPassThroughLimitMinY = static_cast<float>(pConfig.passthrough_limit_min_y);
+        cloudFilterParams.mPassThroughLimitMaxY = static_cast<float>(pConfig.passthrough_limit_max_y);
+        cloudFilterParams.mPassThroughLimitMinZ = static_cast<float>(pConfig.passthrough_limit_min_z);
+        cloudFilterParams.mPassThroughLimitMaxZ = static_cast<float>(pConfig.passthrough_limit_max_z);
+        cloudFilterParams.mVoxelLimitMinZ = static_cast<float>(pConfig.voxel_limit_min_z);
+        cloudFilterParams.mVoxelLimitMaxZ = static_cast<float>(pConfig.voxel_limit_max_z);
+        cloudFilterParams.mVoxelLeafSize = static_cast<float>(pConfig.voxel_leaf_size);
+        mCloudFilter.setParams(cloudFilterParams);
+
+        // CLoud CLustering params
+        mClusterParams.mClusterTolerance = static_cast<float>(pConfig.cluster_tolerance);
+        mClusterParams.mMinClusterSize = static_cast<unsigned int>(pConfig.min_cluster_size);
+        mClusterParams.mMaxClusterSize = static_cast<unsigned int>(pConfig.max_cluster_size);
+    }
+
+    void
+    cloudCallback(const sensor_msgs::PointCloud2::ConstPtr& pCloudMsgPtr)
+    {
+        // do not process cloud when there's no subscriber
+        if (mFilteredCloudPub.getNumSubscribers() == 0 && mMarkerPub.getNumSubscribers() == 0)
+            return;
+
+        // transform the cloud to a desired frame
+        auto transformedCloudPtr = boost::make_shared<sensor_msgs::PointCloud2>();
+        if (!pcl_ros::transformPointCloud(mTargetFrame, *pCloudMsgPtr, *transformedCloudPtr, mTfListener))
+        {
+            ROS_WARN("failed to transform cloud to frame '%s' from frame '%s'",
+                     mTargetFrame.c_str(), pCloudMsgPtr->header.frame_id.c_str());
+            return;
+        }
+
+        // filter the cloud
+        PointCloud::Ptr pclCloudPtr = boost::make_shared<PointCloud>();
+        pcl::fromROSMsg(*transformedCloudPtr, *pclCloudPtr);
+        PointCloud::Ptr filteredCloudPtr = mCloudFilter.filterCloud(pclCloudPtr);
+
+        // publish the filtered cloud for debugging
+        sensor_msgs::PointCloud2::Ptr filteredMsgPtr = boost::make_shared<sensor_msgs::PointCloud2>();
+        pcl::toROSMsg(*filteredCloudPtr, *filteredMsgPtr);
+        mFilteredCloudPub.publish(*filteredMsgPtr);
+
+        // Euclidean clustering
+        pcl::search::Search<PointT>::Ptr tree(new pcl::search::KdTree<PointT>);
+        tree->setInputCloud(filteredCloudPtr);
+        std::vector<pcl::PointIndices> cluster_indices;
+        pcl::extractEuclideanClusters(*filteredCloudPtr,
+                                      tree,
+                                      mClusterParams.mClusterTolerance,
+                                      cluster_indices,
+                                      mClusterParams.mMinClusterSize,
+                                      mClusterParams.mMaxClusterSize);
+
+        publishClusterMarkers(filteredCloudPtr, cluster_indices);
+    }
+
+    void 
+    publishClusterMarkers(PointCloud::ConstPtr filteredCloud, 
+                          const std::vector<pcl::PointIndices>& cluster_indices)
+    {
+        visualization_msgs::MarkerArray markerArray;
+        int i = 0;
+        for (const auto& indices: cluster_indices)
+        {
+            Eigen::Vector4f min, max;
+            pcl::getMinMax3D(*filteredCloud, indices, min, max);
+            markerArray.markers.push_back(getMarker(min, max, i++));
+        }
+        // Publish the marker array
+        mMarkerPub.publish(markerArray);
+    }
+
+    geometry_msgs::Point 
+    getGeomPoint(float x, float y, float z)
+    {
+        geometry_msgs::Point p;
+        p.x = x;
+        p.y = y;
+        p.z = z;
+        return p;
+    }
+
+    visualization_msgs::Marker 
+    getMarker(const Eigen::Vector4f& min, const Eigen::Vector4f& max, int id)
+    {
+        visualization_msgs::Marker marker;
+        marker.type = visualization_msgs::Marker::LINE_LIST;
+        marker.action = visualization_msgs::Marker::ADD;
+        marker.lifetime = ros::Duration(2.0);
+        marker.header.frame_id = mTargetFrame;
+        marker.scale.x = 0.005;
+        marker.scale.y = 0.005;
+        marker.color.a = 2.0;
+        marker.ns = "";
+        marker.id = id;
+        marker.color = std_msgs::ColorRGBA(Color(Color::SCARLET));
+        marker.points.push_back(getGeomPoint(min[0], min[1], min[2]));
+        marker.points.push_back(getGeomPoint(min[0], max[1], min[2]));
+        marker.points.push_back(getGeomPoint(min[0], max[1], min[2]));
+        marker.points.push_back(getGeomPoint(max[0], max[1], min[2]));
+        marker.points.push_back(getGeomPoint(max[0], max[1], min[2]));
+        marker.points.push_back(getGeomPoint(max[0], min[1], min[2]));
+        marker.points.push_back(getGeomPoint(max[0], min[1], min[2]));
+        marker.points.push_back(getGeomPoint(min[0], min[1], min[2]));
+        return marker;
+    }
+};
+
+}   // namespace mas_perception_libs
+
+int main(int pArgc, char** pArgv)
+{
+    ros::init(pArgc, pArgv, "cloud_obstacle_detection");
+    ros::NodeHandle nh("~");
+
+    // load launch parameters
+    std::string cloudTopic, processedCloudTopic, obstacleDetectionsTopic, targetFrame;
+    if (!nh.getParam("cloud_topic", cloudTopic) || cloudTopic.empty())
+    {
+        ROS_ERROR("No 'cloud_topic' specified as parameter");
+        return EXIT_FAILURE;
+    }
+    if (!nh.getParam("processed_cloud_topic", processedCloudTopic) || processedCloudTopic.empty())
+    {
+        ROS_ERROR("No 'processed_cloud_topic' specified as parameter");
+        return EXIT_FAILURE;
+    }
+    if (!nh.getParam("obstacles_detection_topic", obstacleDetectionsTopic) || obstacleDetectionsTopic.empty())
+    {
+        ROS_ERROR("No 'obstacles_detection_topic' specified as parameter");
+        return EXIT_FAILURE;
+    }
+    if (!nh.getParam("target_frame", targetFrame) || targetFrame.empty())
+    {
+        ROS_ERROR("No 'target_frame' specified as parameter");
+        return EXIT_FAILURE;
+    }
+
+    // run cloud filtering and obstacle detection
+    mas_perception_libs::CloudObstacleDetectionNode obstacleDetection(nh, cloudTopic, processedCloudTopic,
+                                                                         targetFrame, obstacleDetectionsTopic);
+
+    while (ros::ok())
+        ros::spin();
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a new feature to simulate a virtual laser scan from a point cloud for objects that lie below the Hokuyo laser scanner on the HSR robot. This enables us to detect small objects lying on the ground which would otherwise go unnoticed.

The PR also adds configuration files for the dynamic reconfiguartion so that the parameters can be tweaked easily when required.

This package depends on the ros package: [pointcloud_to_laserscan](http://wiki.ros.org/pointcloud_to_laserscan)

## Changelog
* Add a new ROS node `cloud_obstacle_detection` for processing point clouds and publishing the filtered obstacle clouds
* Add a launch file to launch the relavant nodes required for simulating the laser scans from the point cloud.
* Add configuration files to support dynamic reconfiguration of the `cloud_obstacle_detection` node

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
