### PR TITLE
Modify ObjectDetectionServer result to include image and roi BB

### DIFF
--- a/ros/src/mas_perception_libs/scene_detection_action.py
+++ b/ros/src/mas_perception_libs/scene_detection_action.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import os
+import copy
 import numpy as np
 import rospy
 import tf
@@ -124,6 +125,7 @@ class ObjectDetectionActionServer(object):
 
         rospy.loginfo('Cloud message received; detecting objects...')
         img_msg = cloud_msg_to_image_msg(cloud_msg)
+        original_img_msg = copy.deepcopy(img_msg)
         try:
             bounding_boxes, classes, confidences = self._detector_handler.process_image_msg(img_msg)
         except RuntimeError as e:
@@ -143,6 +145,7 @@ class ObjectDetectionActionServer(object):
         rospy.loginfo('creating action result and setting success')
         result = ObjectDetectionActionServer._get_action_result(transformed_cloud_msg, bounding_boxes,
                                                                 classes, confidences)
+        result.image = original_img_msg
         self._action_server.set_succeeded(result)
 
     @staticmethod

--- a/ros/src/mas_perception_libs/utils.py
+++ b/ros/src/mas_perception_libs/utils.py
@@ -252,7 +252,7 @@ def get_obj_msg_from_detection(cloud_msg, bounding_box, category, confidence, fr
 
     Keyword arguments:
     cloud_msg: sensor_msgs.msg.PointCloud2
-    bounding_box: Tuple[float, float, float, float] - (xmin, ymin, width, height)
+    bounding_box: BoundingBox2D
     category: str
     confidence: float -- detection confidence
     frame_id: str -- frame of the resulting object
@@ -290,5 +290,10 @@ def get_obj_msg_from_detection(cloud_msg, bounding_box, category, confidence, fr
     detected_obj.pose.pose.position = box_msg.center
     detected_obj.pose.pose.position.x = mean_coord[0]
     detected_obj.pose.pose.orientation.w = 1.0
+
+    detected_obj.roi.x_offset = int(bounding_box.x)
+    detected_obj.roi.y_offset = int(bounding_box.y)
+    detected_obj.roi.width = int(bounding_box.width)
+    detected_obj.roi.height = int(bounding_box.height)
 
     return detected_obj


### PR DESCRIPTION
This PR modifies the `ObjectDetectionActionServer` to include the RGB image in the detection result (following the change to the action message to incorporate an image field [in this PR](https://github.com/b-it-bots/mas_perception_msgs/pull/16) in the `mas_perception_msgs` repository).

Additionally, the roi field of the `Object` message in `utils.py` is now set to the 2D bounding box pixel coordinates.