### PR TITLE
resolve undefined symbol error at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,14 @@ find_package(catkin REQUIRED COMPONENTS
   mas_perception_msgs
 )
 
-set(PY_MAJOR 3)
-set(PY_MINOR 8)
-set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost REQUIRED COMPONENTS python${PY_MAJOR}${PY_MINOR} COMPONENTS numpy${PY_MAJOR}${PY_MINOR})
-find_package(PythonLibs ${PY_MAJOR}.${PY_MINOR} REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(PCL 1.10 REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Development)
+set(BOOST_PYTHON_COMPONENT python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
+set(BOOST_NUMPY_COMPONENT numpy${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
+# It's important to find Boost last so the other libraries won't override Boost-related CMake variables
+# Not doing this may result in odd undefined expression errors at runtime 
+find_package(Boost REQUIRED COMPONENTS ${BOOST_PYTHON_COMPONENT} COMPONENTS ${BOOST_NUMPY_COMPONENT})
 
 catkin_python_setup()
 
@@ -53,7 +54,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  ${PYTHON_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
 )
 
 ###################################
@@ -90,9 +91,11 @@ set_target_properties(_cpp_wrapper PROPERTIES
 target_link_libraries(_cpp_wrapper
   mas_perception_libs
   ${Boost_LIBRARIES}
-  ${PYTHON_LIBRARIES}
-  ${catkin_LIBRARIES}
+  #${Boost_${BOOST_PYTHON_COMPONENT}_LIBRARIES}
+  #${Boost_${BOOST_NUMPY_COMPONENT}_LIBRARIES}
   ${OpenCV_LIBRARIES}
+  ${Python3_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 ###################################

--- a/ros/scripts/plane_detection_action_server
+++ b/ros/scripts/plane_detection_action_server
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 from importlib import import_module
-import os
 
 import rospy
-from mas_perception_libs import PlaneDetectionActionServer
+from mas_perception_libs.scene_detection_action import PlaneDetectionActionServer
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR close #27 

The issue is presumably because `find_package` calls to PCL and OpenCV overwriting some variables created by the call for Boost. Moving finding PCL and OpenCV to before the `find_package` call for Boost seems to fix #27.

This PR includes the following changes:
- move finding PCL and OpenCV to before finding Boost in CMakeLists.txt
- use variables from finding Python3 to populate version info for Boost components
- fix Python import



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
